### PR TITLE
Ignore error message case in comparison for ignorable messages.

### DIFF
--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -127,7 +127,7 @@ func testCheckLabelMap(name string, partialKey string, expectedLabels map[string
 // message to ignore. Returns true if so, false otherwise (also if no ignorable message is given)
 func containsIgnorableErrorMessage(errorMsg string, ignorableErrorMessages ...string) bool {
 	for _, ignorableErrorMessage := range ignorableErrorMessages {
-		if strings.Contains(errorMsg, ignorableErrorMessage) {
+		if strings.Contains(strings.ToLower(errorMsg), strings.ToLower(ignorableErrorMessage)) {
 			return true
 		}
 	}


### PR DESCRIPTION
Case insensitive compare for compatibility with Podman.

I proposed this to the source repo, but it seems to be unmaintained.
https://github.com/kreuzwerker/terraform-provider-docker/pull/583